### PR TITLE
Fixed an issue with "ptcusername" and "ptcpassword" in auth.json

### DIFF
--- a/PokemonGo.RocketAPI/ISettings.cs
+++ b/PokemonGo.RocketAPI/ISettings.cs
@@ -9,8 +9,8 @@ namespace PokemonGo.RocketAPI
         double DefaultLongitude { get; set; }
         double DefaultAltitude { get; set; }
         string GoogleRefreshToken { get; set; }
-        string PtcPassword { get; set; }
         string PtcUsername { get; set; }
+        string PtcPassword { get; set; }
         string GoogleUsername { get; set; }
         string GooglePassword { get; set; }
     }


### PR DESCRIPTION
They were printing out as 
"ptcpassword"
"ptcusername"
instead of vice versa, which is a common standard.
