### PR TITLE
Update Encounter.cs (For Throw Miss PR #4538)

### DIFF
--- a/PokemonGo.RocketAPI/Rpc/Encounter.cs
+++ b/PokemonGo.RocketAPI/Rpc/Encounter.cs
@@ -40,14 +40,14 @@ namespace PokemonGo.RocketAPI.Rpc
             return await PostProtoPayload<Request, UseItemCaptureResponse>(RequestType.UseItemCapture, message);
         }
 
-        public async Task<CatchPokemonResponse> CatchPokemon(ulong encounterId, string spawnPointGuid, ItemId pokeballItemId, double normalizedRecticleSize = 1.950, double spinModifier = 1, double normalizedHitPos = 1)
+        public async Task<CatchPokemonResponse> CatchPokemon(ulong encounterId, string spawnPointGuid, ItemId pokeballItemId, double normalizedRecticleSize = 1.950, double spinModifier = 1, bool hitPokemon = true, double normalizedHitPos = 1)
         {
             var message = new CatchPokemonMessage
             {
                 EncounterId = encounterId,
                 Pokeball = pokeballItemId,
                 SpawnPointId = spawnPointGuid,
-                HitPokemon = true,
+                HitPokemon = hitPokemon,
                 NormalizedReticleSize = normalizedRecticleSize,
                 SpinModifier = spinModifier,
                 NormalizedHitPosition = normalizedHitPos


### PR DESCRIPTION
Need to change the CatchPokemon function to fix error seen on the PR #4538. It was giving a conversion error from bool to double.

Just moved the 'HitPokemon' boolean to before the NormalizedHitPostion to avoid getting the build error.
